### PR TITLE
Add work-around for failure of setup-python github action when using Python 3.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,13 +27,14 @@ jobs:
             pip-trusted-host: 'pypi.python.org pypi.org files.pythonhosted.org'
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
       env:
         PIP_TRUSTED_HOST: ${{ matrix.pip-trusted-host }}
+        PIP_DISABLE_PIP_VERSION_CHECK: 1
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip flake8 setuptools

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,14 +20,20 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13-dev', 'pypy3.10']
-
+        include:
+          - pip-trusted-host: ''
+          # Relax security checks for Python 3.5 only. (https://github.com/actions/setup-python/issues/866)
+          - python-version: '3.5'
+            pip-trusted-host: 'pypi.python.org pypi.org files.pythonhosted.org'
     steps:
     - name: Checkout
       uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+      env:
+        PIP_TRUSTED_HOST: ${{ matrix.pip-trusted-host }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip flake8 setuptools


### PR DESCRIPTION
- Relax security check as described in https://github.com/actions/setup-python/issues/866