### PR TITLE
setup.py: remove test_suite as setuptools 72 dropped support for it

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,14 +24,6 @@ with open(version_path, encoding="utf-8") as f:
     version = version_regex.search(f.read()).group(1)
 
 
-# Running `python setup.py test` should run unit tests (see `test_suite`).
-def all_tests():
-    import unittest
-
-    test_loader = unittest.TestLoader()
-    return test_loader.discover("test")
-
-
 setup(
     name="precis_i18n",
     packages=["precis_i18n"],
@@ -66,5 +58,4 @@ setup(
         "Topic :: Software Development :: Internationalization",
     ],
     zip_safe=True,
-    test_suite="setup.all_tests",
 )


### PR DESCRIPTION
The test command has been deprecated for a long time in setuptools and has finally been removed. Since "python3 -m unittest" can be used to the same effect, simply remove "test_suite" from setup.py.

As an example of the behavior with setuptools 73, the build of the Debian package outputs the following:

  /usr/lib/python3/dist-packages/setuptools/_distutils/dist.py:268: UserWarning: Unknown distribution option: 'test_suite'

Test discovery support was added with python 3.2 according to https://docs.python.org/3.2/library/unittest.html#unittest-test-discovery .